### PR TITLE
Fix page title: "Rainbow Pages Cape Town"

### DIFF
--- a/RainbowPages/app.R
+++ b/RainbowPages/app.R
@@ -15,7 +15,9 @@ curated_data <- read.csv(text=getURL("https://raw.githubusercontent.com/astridit
 
 ui <-  fluidPage(theme=shinytheme("simplex"),
                  setBackgroundColor("#FFF7FA"),
-                 navbarPage(img(src="full_logo.png", height=28),
+                 # title is not a string, so set windowTitle explicitly
+                 navbarPage(windowTitle="Rainbow Pages Cape Town",
+                            title=img(src="full_logo.png", height=28),
                             tabPanel("Browse",
                                      icon=icon("heart"),
                                      fluidPage(


### PR DESCRIPTION
This should make the page title show up as "Rainbow Pages Cape Town", rather than `<img src="full_logo.png" height="28"/>`.